### PR TITLE
add missing dependency 'deepdiff'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyyaml==6.0.1
 obsws-python==1.8.0
 pillow==10.1.0
 python-daemon==3.0.1
+deepdiff==8.6.1

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         "obs-websocket-py==0.5.3",
         "pillow==10.1.0",
         "python-daemon==3.0.1",
+        "deepdiff==8.6.1",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
If 'deepdiff' is not installed, the following error occurs when running “ulanzi-manager” ...

Traceback (most recent call last):
File "/home/mymn/Dokumente/Ulanzi-D200-Linux/ulanzi-d200-linux/venv/bin/ulanzi-manager", line 3, in
from ulanzi_manager.cli import main
File "/home/mymn/Dokumente/Ulanzi-D200-Linux/ulanzi-d200-linux/ulanzi_manager/cli.py", line 9, in
from ulanzi_manager.device import UlanziDevice
File "/home/mymn/Dokumente/Ulanzi-D200-Linux/ulanzi-d200-linux/ulanzi_manager/device.py", line 12, in
from deepdiff import DeepDiff
ModuleNotFoundError: No module named 'deepdiff'
